### PR TITLE
Move @userplot to RecipesBase

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 julia:
-  - 0.5
+  - 0.6
   - nightly
 notifications:
   email: false

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,1 @@
-julia 0.6
+julia 0.6-pre

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,1 @@
-julia 0.5-
-Compat 0.17.0
+julia 0.6

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
 julia 0.5-
-compat 0.17.0
+Compat 0.17.0

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia 0.5-
+compat 0.17.0

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.4-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.4-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 environment:
   matrix:
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.4/julia-0.6-latest-win32.exe"
-  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.4/julia-0.6-latest-win64.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x86/0.6/julia-0.6-latest-win32.exe"
+  - JULIA_URL: "https://julialang-s3.julialang.org/bin/winnt/x64/0.6/julia-0.6-latest-win64.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x86/julia-latest-win32.exe"
   - JULIA_URL: "https://julialangnightlies-s3.julialang.org/bin/winnt/x64/julia-latest-win64.exe"
 

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -3,6 +3,8 @@ __precompile__()
 
 module RecipesBase
 
+using Compat
+
 export
     @recipe,
     @series,
@@ -13,9 +15,9 @@ export
     AbstractLayout
 
 # Common abstract types for the Plots ecosystem
-abstract AbstractBackend
-abstract AbstractPlot{T<:AbstractBackend}
-abstract AbstractLayout
+@compat abstract type AbstractBackend end
+@compat abstract type AbstractPlot{T<:AbstractBackend} end
+@compat abstract type AbstractLayout end
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.plot since RecipesBase is the common

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -351,8 +351,8 @@ macro shorthands(funcname::Symbol)
     funcname2 = Symbol(funcname, "!")
     esc(quote
         export $funcname, $funcname2
-        $funcname(args...; kw...) = plot(args...; kw..., seriestype = $(quot(funcname)))
-        $funcname2(args...; kw...) = plot!(args...; kw..., seriestype = $(quot(funcname)))
+        $funcname(args...; kw...) = plot(args...; kw..., seriestype = $(Meta.quot(funcname)))
+        $funcname2(args...; kw...) = plot!(args...; kw..., seriestype = $(Meta.quot(funcname)))
     end)
 end
 

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -24,6 +24,11 @@ abstract type AbstractLayout end
 function plot end
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
+# can add their own definition of RecipesBase.animate since RecipesBase is the common
+# dependency of the Plots ecosystem
+function animate end
+
+# a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.is_key_supported(k::Symbol)
 function is_key_supported end
 

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -29,10 +29,6 @@ function plot end
 # can add their own definition of RecipesBase.is_key_supported(k::Symbol)
 function is_key_supported end
 
-# a commonly used function in recipes, thus defined here for Plots.jl to extend
-# not related to Base.cycle
-function _cycle end
-
 # This holds the recipe definitions to be dispatched on
 # the function takes in an attribute dict `d` and a list of args.
 # This default definition specifies the "no-arg" case.

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -25,7 +25,8 @@ function plot end
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.animate since RecipesBase is the common
-# dependency of the Plots ecosystem
+# dependency of the Plots ecosystem. Plots.jl will handle the basic cases, while
+# other packages can now extend for their types
 function animate end
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -26,6 +26,10 @@ function plot end
 # can add their own definition of RecipesBase.is_key_supported(k::Symbol)
 function is_key_supported end
 
+# a commonly used function in recipes, thus defined here for Plots.jl to extend
+# not related to Base.cycle
+function _cycle end
+
 # This holds the recipe definitions to be dispatched on
 # the function takes in an attribute dict `d` and a list of args.
 # This default definition specifies the "no-arg" case.

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -9,6 +9,11 @@ export
     RecipeData
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
+# can add their own definition of RecipesBase.plot since RecipesBase is the common
+# dependency of the Plots ecosystem
+function plot end
+
+# a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.is_key_supported(k::Symbol)
 function is_key_supported end
 

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -7,7 +7,15 @@ export
     @recipe,
     @series,
     @userplot,
-    RecipeData
+    RecipeData,
+    AbstractBackend,
+    AbstractPlot,
+    AbstractLayout
+
+# Common abstract types for the Plots ecosystem
+abstract AbstractBackend
+abstract AbstractPlot{T<:AbstractBackend}
+abstract AbstractLayout
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.plot since RecipesBase is the common

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -3,8 +3,6 @@ __precompile__()
 
 module RecipesBase
 
-using Compat
-
 export
     @recipe,
     @series,
@@ -16,9 +14,9 @@ export
     AbstractLayout
 
 # Common abstract types for the Plots ecosystem
-@compat abstract type AbstractBackend end
-@compat abstract type AbstractPlot{T<:AbstractBackend} end
-@compat abstract type AbstractLayout end
+abstract type AbstractBackend end
+abstract type AbstractPlot{T<:AbstractBackend} end
+abstract type AbstractLayout end
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.plot since RecipesBase is the common

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -282,4 +282,45 @@ end
 
 # --------------------------------------------------------------------------
 
+"""
+You can easily define your own plotting recipes with convenience methods:
+```
+@userplot type GroupHist
+    args
+end
+@recipe function f(gh::GroupHist)
+    # set some attributes, add some series, using gh.args as input
+end
+# now you can plot like:
+grouphist(rand(1000,4))
+```
+"""
+macro userplot(expr)
+    _userplot(expr)
+end
+
+function _userplot(expr::Expr)
+    if expr.head != :type
+        errror("Must call userplot on a type/immutable expression.  Got: $expr")
+    end
+
+    typename = expr.args[2]
+    funcname = Symbol(lowercase(string(typename)))
+    funcname2 = Symbol(funcname, "!")
+
+    # return a code block with the type definition and convenience plotting methods
+    esc(quote
+        $expr
+        export $funcname, $funcname2
+        $funcname(args...; kw...) = plot($typename(args); kw...)
+        $funcname2(args...; kw...) = plot!($typename(args); kw...)
+    end)
+end
+
+function _userplot(sym::Symbol)
+    _userplot(:(type $sym
+            args
+    end))
+end
+
 end # module

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -9,6 +9,7 @@ export
     @recipe,
     @series,
     @userplot,
+    @shorthands,
     RecipeData,
     AbstractBackend,
     AbstractPlot,
@@ -341,6 +342,18 @@ function _userplot(sym::Symbol)
     _userplot(:(type $sym
             args
     end))
+end
+
+#----------------------------------------------------------------------------
+
+# define and export shorthand plotting method definitions
+macro shorthands(funcname::Symbol)
+    funcname2 = Symbol(funcname, "!")
+    esc(quote
+        export $funcname, $funcname2
+        $funcname(args...; kw...) = plot(args...; kw..., seriestype = $(quot(funcname)))
+        $funcname2(args...; kw...) = plot!(args...; kw..., seriestype = $(quot(funcname)))
+    end)
 end
 
 end # module

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -6,6 +6,7 @@ module RecipesBase
 export
     @recipe,
     @series,
+    @userplot,
     RecipeData
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)


### PR DESCRIPTION
It makes sense. It's used in libraries which use recipes but don't want to depend directly on Plots.jl. For example: PlotRecipes.jl.