### PR TITLE
Replace d

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -80,7 +80,7 @@ function get_function_def(func_signature::Expr, args::Vector)
     if func_signature.head == :where
         Expr(:where, get_function_def(front, args), esc.(func_signature.args[2:end])...)
     elseif func_signature.head == :call
-        func = Expr(:call, :(RecipesBase.apply_recipe), esc.([:(d::Dict{Symbol, Any}); args])...)
+        func = Expr(:call, :(RecipesBase.apply_recipe), esc.([:($PLOTATTRIBUTES::Dict{Symbol, Any}); args])...)
         if isa(front, Expr) && front.head == :curly
             Expr(:where, func, esc.(front.args[2:end])...)
         else
@@ -276,7 +276,6 @@ macro recipe(funcexpr::Expr)
 
     # now build a function definition for apply_recipe, wrapping the return value in a tuple if needed.
     # we are creating a vector of RecipeData objects, one per series.
-<<<<<<< HEAD
     funcdef = Expr(:function, func, esc(quote
         if RecipesBase._debug_recipes[1]
             println("apply_recipe args: ", $args)
@@ -286,29 +285,11 @@ macro recipe(funcexpr::Expr)
         series_list = RecipesBase.RecipeData[]
         func_return = $func_body
         if func_return != nothing
-            push!(series_list, RecipesBase.RecipeData(d, RecipesBase.wrap_tuple(func_return)))
+            push!(series_list, RecipesBase.RecipeData($PLOTATTRIBUTES, RecipesBase.wrap_tuple(func_return)))
         end
         series_list
     end))
     funcdef
-=======
-    funcdef = esc(quote
-        $deprecation_body
-        function $func($PLOTATTRIBUTES::Dict{Symbol,Any}, $(args...))
-            if RecipesBase._debug_recipes[1]
-                println("apply_recipe args: ", $args)
-            end
-            $kw_body
-            $cleanup_body
-            series_list = RecipesBase.RecipeData[]
-            func_return = $func_body
-            if func_return != nothing
-                push!(series_list, RecipesBase.RecipeData($PLOTATTRIBUTES, RecipesBase.wrap_tuple(func_return)))
-            end
-            series_list
-        end
-    end)
->>>>>>> 4b4a501... replace d by plotattribues
 end
 
 

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -101,8 +101,8 @@ function create_kw_body(func_signature::Expr)
     if isa(args[1], Expr) && args[1].head == :parameters
         for kwpair in args[1].args
             k, v = kwpair.args
-            push!(kw_body.args, :($k = get!(d, $(QuoteNode(k)), $v)))
-            push!(cleanup_body.args, :(RecipesBase.is_key_supported($(QuoteNode(k))) || delete!(d, $(QuoteNode(k)))))
+            push!(kw_body.args, :($k = get!($PLOTATTRIBUTES, $(QuoteNode(k)), $v)))
+            push!(cleanup_body.args, :(RecipesBase.is_key_supported($(QuoteNode(k))) || delete!($PLOTATTRIBUTES, $(QuoteNode(k)))))
         end
         args = args[2:end]
     end
@@ -155,10 +155,10 @@ function process_recipe_body!(expr::Expr)
 
                 set_expr = if force
                     # forced override user settings
-                    :(d[$k] = $v)
+                    :($PLOTATTRIBUTES[$k] = $v)
                 else
                     # if the user has set this keyword, use theirs
-                    :(get!(d, $k, $v))
+                    :(get!($PLOTATTRIBUTES, $k, $v))
                 end
 
                 expr.args[i] = if quiet
@@ -182,6 +182,20 @@ function process_recipe_body!(expr::Expr)
     end
 end
 
+# PLOTATTRIBUTES_OLD and_replace can be removed after d for accessing plot attributes is
+# is not supported anymore
+const PLOTATTRIBUTES = :plotattributes
+const PLOTATTRIBUTES_OLD = :d
+_replace(ex, old, new) = _replace(ex, 0, old, new)
+_replace(ex, n, old, new) = (ex == old) ? (new, n+1) : (ex, n)
+function _replace(ex::Expr, n, old, new)
+    new_args = []
+    for old_arg in ex.args
+        new_arg, n = _replace(old_arg, n, old, new)
+        push!(new_args, new_arg)
+    end
+    Expr(ex.head, new_args...), n
+end
 # --------------------------------------------------------------------------
 
 """
@@ -233,8 +247,15 @@ number of series to display.  User-defined keyword arguments are passed through,
 - force:   Don't allow user override for this keyword
 """
 macro recipe(funcexpr::Expr)
+    funcexpr, n_depr = _replace(funcexpr, PLOTATTRIBUTES_OLD, PLOTATTRIBUTES)
     func_signature, func_body = funcexpr.args
 
+    if n_depr > 0
+        msg = "Usage of `$PLOTATTRIBUTES_OLD` for accessing plot attributes is deprecated. Found $n_depr usages of `$PLOTATTRIBUTES_OLD` inside `@recipe`. Use `$PLOTATTRIBUTES` instead.\n"
+        deprecation_body = :(Base.depwarn($msg, :d))
+    else
+        deprecation_body = :()
+    end
     if !(funcexpr.head in (:(=), :function))
         error("Must wrap a valid function call!")
     end
@@ -255,6 +276,7 @@ macro recipe(funcexpr::Expr)
 
     # now build a function definition for apply_recipe, wrapping the return value in a tuple if needed.
     # we are creating a vector of RecipeData objects, one per series.
+<<<<<<< HEAD
     funcdef = Expr(:function, func, esc(quote
         if RecipesBase._debug_recipes[1]
             println("apply_recipe args: ", $args)
@@ -269,6 +291,24 @@ macro recipe(funcexpr::Expr)
         series_list
     end))
     funcdef
+=======
+    funcdef = esc(quote
+        $deprecation_body
+        function $func($PLOTATTRIBUTES::Dict{Symbol,Any}, $(args...))
+            if RecipesBase._debug_recipes[1]
+                println("apply_recipe args: ", $args)
+            end
+            $kw_body
+            $cleanup_body
+            series_list = RecipesBase.RecipeData[]
+            func_return = $func_body
+            if func_return != nothing
+                push!(series_list, RecipesBase.RecipeData($PLOTATTRIBUTES, RecipesBase.wrap_tuple(func_return)))
+            end
+            series_list
+        end
+    end)
+>>>>>>> 4b4a501... replace d by plotattribues
 end
 
 
@@ -298,9 +338,9 @@ end
 """
 macro series(expr::Expr)
     esc(quote
-        let d = copy(d)
+        let $PLOTATTRIBUTES = copy($PLOTATTRIBUTES)
             args = $expr
-            push!(series_list, RecipesBase.RecipeData(d, RecipesBase.wrap_tuple(args)))
+            push!(series_list, RecipesBase.RecipeData($PLOTATTRIBUTES, RecipesBase.wrap_tuple(args)))
             nothing
         end
     end)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -38,6 +38,7 @@ end
         rand(10, n)
     end
 
+<<<<<<< HEAD
     srand(1)
     check_apply_recipe(T1, KW(
         :customcolor => :red,
@@ -92,3 +93,29 @@ end
 
 
 end  # @testset "@recipe"
+=======
+@recipe function plot{N<:Integer}(t::T, n::N = 1; customcolor = :green)
+    :markershape --> :auto, :require
+    :markercolor --> customcolor, :force
+    :xrotation --> 5
+    :zrotation --> 6, :quiet
+    plotattributes[:hello] = "hi"
+    rand(10,n)
+end
+
+# this is similar to how Plots would call the method
+typealias KW Dict{Symbol,Any}
+d = KW(:customcolor => :red)
+data_list = RecipesBase.apply_recipe(d, T(), 2)
+
+# make sure the attribute dictionary was populated correctly, and the returned arguments are as expected
+@test data_list[1].args == (srand(1); (rand(10,2),))
+@test d == KW(
+    :customcolor => :red,
+    :markershape => :auto,
+    :markercolor => :red,
+    :xrotation => 5,
+    :zrotation => 6,
+    :hello => "hi"
+)
+>>>>>>> 4b4a501... replace d by plotattribues

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,7 +5,7 @@ const KW = Dict{Symbol, Any}
 
 RecipesBase.is_key_supported(k::Symbol) = true
 
-for t in [Symbol(:T, i) for i in 1:3]
+for t in [Symbol(:T, i) for i in 1:4]
     @eval struct $t end
 end
 
@@ -38,7 +38,6 @@ end
         rand(10, n)
     end
 
-<<<<<<< HEAD
     srand(1)
     check_apply_recipe(T1, KW(
         :customcolor => :red,
@@ -92,30 +91,24 @@ end
 end
 
 
-end  # @testset "@recipe"
-=======
-@recipe function plot{N<:Integer}(t::T, n::N = 1; customcolor = :green)
-    :markershape --> :auto, :require
-    :markercolor --> customcolor, :force
-    :xrotation --> 5
-    :zrotation --> 6, :quiet
-    plotattributes[:hello] = "hi"
-    rand(10,n)
-end
-
-# this is similar to how Plots would call the method
-typealias KW Dict{Symbol,Any}
-d = KW(:customcolor => :red)
-data_list = RecipesBase.apply_recipe(d, T(), 2)
-
-# make sure the attribute dictionary was populated correctly, and the returned arguments are as expected
-@test data_list[1].args == (srand(1); (rand(10,2),))
-@test d == KW(
+@testset "manual access of plotattributes" begin
+    @recipe function plot(t::T4, n = 1; customcolor = :green)
+        :markershape --> :auto, :require
+        :markercolor --> customcolor, :force
+        :xrotation --> 5
+        :zrotation --> 6, :quiet
+        plotattributes[:hello] = "hi"
+        rand(10,n)
+    end
+    srand(1)
+    check_apply_recipe(T4, KW(
     :customcolor => :red,
     :markershape => :auto,
     :markercolor => :red,
     :xrotation => 5,
     :zrotation => 6,
     :hello => "hi"
-)
->>>>>>> 4b4a501... replace d by plotattribues
+   ))
+end
+
+end  # @testset "@recipe"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -98,6 +98,7 @@ end
         :xrotation --> 5
         :zrotation --> 6, :quiet
         plotattributes[:hello] = "hi"
+        d[:world] = "world"
         rand(10,n)
     end
     srand(1)
@@ -107,7 +108,8 @@ end
     :markercolor => :red,
     :xrotation => 5,
     :zrotation => 6,
-    :hello => "hi"
+    :hello => "hi",
+    :world => "world"
    ))
 end
 


### PR DESCRIPTION
This PR is part of the plan to replace `d` inside `@recipes`. See #10. 

## Stage 1
- [x] Deprecation warning for using `d` in recipes.
- [X] Allow using `plotattributes` instead of `d`.
#### PRs to JuliaPlots packages
- [x] PlotDocs.
- [x] Plots
- [x] PlotRecipes
- [x] StatPlots

## Stage 2
#### PRs to registered packages with `d` in recipes.
- [ ] DynamicMovementPrimitives
- [ ] ImplicitEquations
- [ ] JWAS
- [ ] LPVSpectral
- [ ] PyDSTool
- [ ] SpatialEcology
- [ ] SymPy
- [ ] TimeSeries
- [ ] ValueHistories

## Stage 3
- [ ] Remove support of d completely

