### PR TITLE
Allow where syntax in recipe definition (fix #21)

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -77,11 +77,12 @@ end
 function get_function_def(func_signature::Expr, args::Vector)
     front = func_signature.args[1]
     if func_signature.head == :where
-        Expr(:where, get_function_def(front, args), [esc(arg) for arg in func_signature.args[2:end]]...)
+        Expr(:where, get_function_def(front, args), esc.(func_signature.args[2:end])...)
     elseif func_signature.head == :call
-        func = Expr(:call, :(RecipesBase.apply_recipe), [esc(arg) for arg in [:(d::Dict{Symbol, Any}); args]]...)
+        func = Expr(:call, :(RecipesBase.apply_recipe), esc.([:(d::Dict{Symbol, Any}); args])...)
         if isa(front, Expr) && front.head == :curly
-            Expr(:where, func, [esc(arg) for arg in front.args[2:end]]...)
+            # Expr(:where, func, [esc(arg) for arg in front.args[2:end]]...)
+            Expr(:where, func, esc.(front.args[2:end])...)
         else
             func
         end

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -81,7 +81,6 @@ function get_function_def(func_signature::Expr, args::Vector)
     elseif func_signature.head == :call
         func = Expr(:call, :(RecipesBase.apply_recipe), esc.([:(d::Dict{Symbol, Any}); args])...)
         if isa(front, Expr) && front.head == :curly
-            # Expr(:where, func, [esc(arg) for arg in front.args[2:end]]...)
             Expr(:where, func, esc.(front.args[2:end])...)
         else
             func

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -77,16 +77,16 @@ end
 function get_function_def(func_signature::Expr, args::Vector)
     front = func_signature.args[1]
     if func_signature.head == :where
-        Expr(:where, get_function_def(front, args), func_signature.args[2:end]...)
+        Expr(:where, get_function_def(front, args), [esc(arg) for arg in func_signature.args[2:end]]...)
     elseif func_signature.head == :call
-        func = Expr(:call, :(RecipesBase.apply_recipe), :(d::Dict{Symbol, Any}), args...)
+        func = Expr(:call, :(RecipesBase.apply_recipe), [esc(arg) for arg in [:(d::Dict{Symbol, Any}); args]]...)
         if isa(front, Expr) && front.head == :curly
-            Expr(:where, func, front.args[2:end]...)
+            Expr(:where, func, [esc(arg) for arg in front.args[2:end]]...)
         else
             func
         end
     else
-        error("Expected `func_signature = ...` with func_signature as a call Expr... got: $func_signature")
+        error("Expected `func_signature = ...` with func_signature as a call or where Expr... got: $func_signature")
     end
 end
 

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -237,6 +237,9 @@ macro recipe(funcexpr::Expr)
     if !(funcexpr.head in (:(=), :function))
         error("Must wrap a valid function call!")
     end
+    if !(isa(func_signature, Expr) && func_signature.head in (:call, :where))
+        error("Expected `func_signature = ...` with func_signature as a call or where Expr... got: $func_signature")
+    end
     if length(func_signature.args) < 2
         error("Missing function arguments... need something to dispatch on!")
     end


### PR DESCRIPTION
With this the where syntax is supported when defining recipes.
Also `@recipe function f{T <: SomeType}(x::T)` is converted to the where syntax in the apply_recipe definition: `function RecipesBase.apply_recipe(d::Dict{Symbol, Any}, x::T) where T <: SomeType`. I hope that's not a problem.

I tested this with:
```julia
using Plots; backend()


# ------------------------------------------------------------------------------
# type definitions

mytypes = [Symbol(:MyType, i) for i in 1:6]

for t in mytypes
    @eval struct $t{T <: Real}
        x::Vector{T}
    end
end


# ------------------------------------------------------------------------------
# recipe definitions

@recipe f(mt::MyType1) = mt.x

@recipe function f(mt::MyType2)
    mt.x
end

@recipe f{T <: MyType3}(mt::T) = mt.x

@recipe function f{T <: MyType4}(mt::T)
    mt.x
end

@recipe f(mt::T) where {T <: MyType5} = mt.x

@recipe function f(mt::T) where {T <: MyType6}
    mt.x
end


# ------------------------------------------------------------------------------
# plots

plot(MyType1(rand(10)))
plot(MyType2(rand(10)))
plot(MyType3(rand(10)))
plot(MyType4(rand(10)))
plot(MyType5(rand(10)))
plot(MyType6(rand(10)))
```

and with `Plots/test/runtests.jl` - not sure whether this covers enough cases.
Looking forward to any comments :)