### PR TITLE
add plot! function definition

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -22,6 +22,7 @@ abstract type AbstractLayout end
 # can add their own definition of RecipesBase.plot since RecipesBase is the common
 # dependency of the Plots ecosystem
 function plot end
+function plot! end
 
 # a placeholder to establish the name so that other packages (Plots.jl for example)
 # can add their own definition of RecipesBase.animate since RecipesBase is the common


### PR DESCRIPTION
With #24 some Plots testimages stopped to work. (e.g. `test_examples(:gr, 4)`)
This defines a `plot!` placeholder in RecipesBase. `plot!` also needs to be imported in Plots.jl now.