### PR TITLE
typo on line 352

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -349,7 +349,7 @@ end
 
 function _userplot(expr::Expr)
     if expr.head != :type
-        errror("Must call userplot on a type/immutable expression.  Got: $expr")
+        error("Must call userplot on a type/immutable expression.  Got: $expr")
     end
 
     typename = expr.args[2]


### PR DESCRIPTION
```errror``` is a typo
Plots still does not compile on v0.7, get the following error stacktrace:
```

ERROR: LoadError: LoadError: LoadError: Must call userplot on a type/immutable expression.  Got: mutable struct Spy
    #= /Users/kevin/.julia/v0.7/RecipesBase/src/RecipesBase.jl:370 =#
    args
end
Stacktrace:
 [1] _userplot(::Expr) at /Users/kevin/.julia/v0.7/RecipesBase/src/RecipesBase.jl:352
 [2] _userplot(::Symbol) at /Users/kevin/.julia/v0.7/RecipesBase/src/RecipesBase.jl:369
 [3] @userplot(::LineNumberNode, ::Module, ::Any) at /Users/kevin/.julia/v0.7/RecipesBase/src/RecipesBase.jl:347
 [4] include_relative(::Module, ::String) at ./loading.jl:526
 [5] include at ./sysimg.jl:14 [inlined]
 [6] include(::String) at /Users/kevin/.julia/v0.7/Plots/src/Plots.jl:3
 [7] include_relative(::Module, ::String) at ./loading.jl:526
 [8] _require(::Symbol) at ./loading.jl:461
 [9] require(::Symbol) at ./loading.jl:320
in expression starting at /Users/kevin/.julia/v0.7/Plots/src/recipes.jl:930
in expression starting at /Users/kevin/.julia/v0.7/Plots/src/recipes.jl:930
in expression starting at /Users/kevin/.julia/v0.7/Plots/src/Plots.jl:154