### PR TITLE
changed `type` to new `struct` keyword

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -333,7 +333,7 @@ end
 """
 You can easily define your own plotting recipes with convenience methods:
 ```
-@userplot type GroupHist
+@userplot struct GroupHist
     args
 end
 @recipe function f(gh::GroupHist)

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -333,9 +333,8 @@ end
 """
 You can easily define your own plotting recipes with convenience methods:
 ```
-@userplot struct GroupHist
-    args
-end
+@userplot GroupHist
+
 @recipe function f(gh::GroupHist)
     # set some attributes, add some series, using gh.args as input
 end

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -348,8 +348,8 @@ macro userplot(expr)
 end
 
 function _userplot(expr::Expr)
-    if expr.head != :type
-        errror("Must call userplot on a type/immutable expression.  Got: $expr")
+    if expr.head != :struct
+        errror("Must call userplot on a [mutable] struct expression.  Got: $expr")
     end
 
     typename = expr.args[2]


### PR DESCRIPTION
i ran into this issue trying to use plots on 0.7.0: the expression head of types is no longe `type` but `struct`.
Also fixed the error message.
I fixed the typo in `errror` in an earlier PR - these should be merged, but i don't really know what would be the expected way to handle this.