### PR TITLE
RFC: Make `userplots` and `shorthand` macros documentable

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -360,8 +360,8 @@ function _userplot(expr::Expr)
     esc(quote
         $expr
         export $funcname, $funcname2
-        $funcname(args...; kw...) = RecipesBase.plot($typename(args); kw...)
-        $funcname2(args...; kw...) = RecipesBase.plot!($typename(args); kw...)
+        Core.@__doc__ $funcname(args...; kw...) = RecipesBase.plot($typename(args); kw...)
+        Core.@__doc__ $funcname2(args...; kw...) = RecipesBase.plot!($typename(args); kw...)
     end)
 end
 
@@ -378,8 +378,8 @@ macro shorthands(funcname::Symbol)
     funcname2 = Symbol(funcname, "!")
     esc(quote
         export $funcname, $funcname2
-        $funcname(args...; kw...) = RecipesBase.plot(args...; kw..., seriestype = $(Meta.quot(funcname)))
-        $funcname2(args...; kw...) = RecipesBase.plot!(args...; kw..., seriestype = $(Meta.quot(funcname)))
+        Core.@__doc__ $funcname(args...; kw...) = RecipesBase.plot(args...; kw..., seriestype = $(Meta.quot(funcname)))
+        Core.@__doc__ $funcname2(args...; kw...) = RecipesBase.plot!(args...; kw..., seriestype = $(Meta.quot(funcname)))
     end)
 end
 


### PR DESCRIPTION
You should now be able to directly do something like this:
```julia
"""
    streamlines(x, y, elements)

Draw the streamlines of `elements` in the rectangular region defined by `x` and `y`
"""
@userplot streamlines
```