### PR TITLE
Check if k is a type annotation

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -102,6 +102,9 @@ function create_kw_body(func_signature::Expr)
     if isa(args[1], Expr) && args[1].head == :parameters
         for kwpair in args[1].args
             k, v = kwpair.args
+            if isa(k, Expr) && k.head == :(::)
+                k = k.args[1]
+            end
             push!(kw_body.args, :($k = get!($PLOTATTRIBUTES, $(QuoteNode(k)), $v)))
             push!(cleanup_body.args, :(RecipesBase.is_key_supported($(QuoteNode(k))) || delete!($PLOTATTRIBUTES, $(QuoteNode(k)))))
         end

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -104,7 +104,7 @@ function create_kw_body(func_signature::Expr)
             k, v = kwpair.args
             if isa(k, Expr) && k.head == :(::)
                 k = k.args[1]
-                warn("Type annotations on keyword arguments not currently supported. Type information has been discarded")
+                warn("Type annotations on keyword arguments not currently supported in recipes. Type information has been discarded")
             end
             push!(kw_body.args, :($k = get!($PLOTATTRIBUTES, $(QuoteNode(k)), $v)))
             push!(cleanup_body.args, :(RecipesBase.is_key_supported($(QuoteNode(k))) || delete!($PLOTATTRIBUTES, $(QuoteNode(k)))))

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -104,6 +104,7 @@ function create_kw_body(func_signature::Expr)
             k, v = kwpair.args
             if isa(k, Expr) && k.head == :(::)
                 k = k.args[1]
+                warn("Type annotations on keyword arguments not currently supported. Type information has been discarded")
             end
             push!(kw_body.args, :($k = get!($PLOTATTRIBUTES, $(QuoteNode(k)), $v)))
             push!(cleanup_body.args, :(RecipesBase.is_key_supported($(QuoteNode(k))) || delete!($PLOTATTRIBUTES, $(QuoteNode(k)))))


### PR DESCRIPTION
This fixes the error in JuliaPlots/Plots.jl/issues/1292, but it simply discards the type annotation on the keyword argument.