### PR TITLE
Add specialized in-place method to `@userplot`

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -349,6 +349,7 @@ function _userplot(expr::Expr)
         export $funcname, $funcname2
         Core.@__doc__ $funcname(args...; kw...) = RecipesBase.plot($typename(args); kw...)
         Core.@__doc__ $funcname2(args...; kw...) = RecipesBase.plot!($typename(args); kw...)
+        Core.@__doc__ $funcname2(plt::AbstractPlot, args...; kw...) = RecipesBase.plot!(plt, $typename(args); kw...)
     end)
 end
 


### PR DESCRIPTION
Hej!

I noticed that currently the `@userplot` macro does not define a method that allows to add the custom plot to an arbitrary existing plot. The following example from the StatsPlots documentation illustrates the problem:
```julia
using StatsPlots, Distributions
using Random

Random.seed!(1234)
const x = rand(Normal(), 100)
const y = rand(Cauchy(), 100)

function test_github()
    plot(qqplot(x, y, qqline = :fit),
         qqplot(Cauchy, y),
         qqnorm(x, qqline = :R),
         layout = (1, 3))
end

function test_implicit()
    plt = plot(layout = (1,3))
    qqplot!(x, y, qqline = :fit, subplot = 1)
    qqplot!(Cauchy, y, subplot = 2)
    qqnorm!(x, qqline = :R, subplot = 3)
    plt
end

function test_explicit()
    plt = plot(layout = (1,3))
    qqplot!(plt, x, y, qqline = :fit, subplot = 1)
    qqplot!(plt, Cauchy, y, subplot = 2)
    qqnorm!(plt, x, qqline = :R, subplot = 3)
    plt
end
```
On the current master of RecipesBase, `test_github` and `test_implicit` work but `test_explicit` fails:
```julia
julia> test_explicit()
ERROR: MethodError: no method matching qqbuild(::Plots.Plot{Plots.GRBackend}, ::Array{Float64,1})
Closest candidates are:
  qqbuild(::Array{T,1} where T, ::Array{T,1} where T) at /home/david/.julia/packages/Distributions/0Wogo/src/qq.jl:7
  qqbuild(::Distribution{Univariate,S} where S<:ValueSupport, ::Array{T,1} where T) at /home/david/.julia/packages/Distributions/0Wogo/src/qq.jl:23
Stacktrace:
 [1] apply_recipe(::Dict{Symbol,Any}, ::StatsPlots.QQPlot) at /home/david/.julia/packages/RecipesBase/Uz5AO/src/RecipesBase.jl:275
 [2] _process_userrecipes(::Plots.Plot{Plots.GRBackend}, ::Dict{Symbol,Any}, ::Tuple{StatsPlots.QQPlot}) at /home/david/.julia/packages/Plots/oiirH/src/pipeline.jl:83
 [3] _plot!(::Plots.Plot{Plots.GRBackend}, ::Dict{Symbol,Any}, ::Tuple{StatsPlots.QQPlot}) at /home/david/.julia/packages/Plots/oiirH/src/plot.jl:178
 [4] #plot!#137 at /home/david/.julia/packages/Plots/oiirH/src/plot.jl:158 [inlined]
 [5] (::getfield(RecipesBase, Symbol("#kw##plot!")))(::NamedTuple{(:qqline, :subplot),Tuple{Symbol,Int64}}, ::typeof(plot!), ::Plots.Plot{Plots.GRBackend}, ::StatsPlots.QQPlot) at ./none:0
 [6] #plot!#136(::Base.Iterators.Pairs{Symbol,Any,Tuple{Symbol,Symbol},NamedTuple{(:qqline, :subplot),Tuple{Symbol,Int64}}}, ::Function, ::StatsPlots.QQPlot) at /home/david/.julia/packages/Plots/oiirH/src/plot.jl:150
 [7] #plot! at ./none:0 [inlined]
 [8] #qqplot!#75 at /home/david/.julia/packages/RecipesBase/Uz5AO/src/RecipesBase.jl:351 [inlined]
 [9] #qqplot! at ./none:0 [inlined]
 [10] test_explicit() at /home/david/Documents/Projects/julia/develop/Plots/test_userplot.jl:27
 [11] top-level scope at none:0
```
The problem is that currently the macro forwards all arguments, and hence also the existing plot `plt`, to the user plot type.

I expected that `test_explicit` would just work in the same way as `test_implicit` and `test_github`, so I added another method that dispatches on the first argument. I'm not completely familiar with all details of the Plots ecosystem, so maybe there's another better way to fix this inconvenience :smiley: 