### PR TITLE
Fix missing RecipesBase. prefix in @userplot.

### DIFF
--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -349,7 +349,7 @@ function _userplot(expr::Expr)
         export $funcname, $funcname2
         Core.@__doc__ $funcname(args...; kw...) = RecipesBase.plot($typename(args); kw...)
         Core.@__doc__ $funcname2(args...; kw...) = RecipesBase.plot!($typename(args); kw...)
-        Core.@__doc__ $funcname2(plt::AbstractPlot, args...; kw...) = RecipesBase.plot!(plt, $typename(args); kw...)
+        Core.@__doc__ $funcname2(plt::RecipesBase.AbstractPlot, args...; kw...) = RecipesBase.plot!(plt, $typename(args); kw...)
     end)
 end
 


### PR DESCRIPTION
This PR fixes a scoping bug in `@userplot`. If a package uses `import RecipesBase` instead of `using RecipesBase`, then structs like `AbstractPlot` aren't pulled into the namespace and need to be scoped appropriately. 

The leads to this error:
```Julia
ERROR: LoadError: LoadError: UndefVarError: AbstractPlot not defined
Stacktrace:
 [1] top-level scope at /home/travis/.julia/packages/RecipesBase/zBoFG/src/RecipesBase.jl:352
 [2] include at ./boot.jl:317 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:1044
 [4] include at ./sysimg.jl:29 [inlined]
 [5] include(::String) at /home/travis/build/odow/SDDP.jl/src/SDDP.jl:6
 [6] top-level scope at none:0
 [7] include at ./boot.jl:317 [inlined]
 [8] include_relative(::Module, ::String) at ./loading.jl:1044
 [9] include(::Module, ::String) at ./sysimg.jl:29
 [10] top-level scope at none:2
 [11] eval at ./boot.jl:319 [inlined]
 [12] eval(::Expr) at ./client.jl:393
 [13] top-level scope at ./none:3
```

See this Travis log for the original failure: https://travis-ci.org/odow/SDDP.jl/jobs/545251695#L556-L570