### PR TITLE
allow `return` in `@recipe`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.jl.*.cov
 *.jl.mem
 Manifest.toml
+dev/

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -185,7 +185,9 @@ function process_recipe_body!(expr::Expr)
                     set_expr
                 end
 
-            # TODO elseif it's a @series macrocall, add a series block and push to the `series` list
+            elseif e.head == :return
+                # To allow `return` in recipes just extract the returned arguments.
+                expr.args[i] = first(e.args)
 
             elseif e.head != :call
                 # we want to recursively replace the arrows, but not inside function calls


### PR DESCRIPTION
Fix #58 

Allows
```julia
@recipe function f(...)
    ...
    @series begin
        ...
        return series_args
    end
    ...
    return recipe_args
end
```
Tested for all user and type recipes in https://daschw.github.io/recipes/ (not relevant for plot and series recipes)