### PR TITLE
Update link to Plots.jl documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ Really there's very little that *couldn't* be mapped to a useful visualization.
 I challenge you to create the pictures that are worth a thousand words.
 
 For more information about Plots, see [the docs](http://juliaplots.github.io/), and be sure to reference
-the [supported keywords](http://docs.juliaplots.org/latest/supported/#keyword-arguments).
+the [supported keywords](https://docs.juliaplots.org/stable/generated/supported/#Keyword-Arguments).
 For additional examples of recipes in the wild, see [PlotRecipes](https://github.com/JuliaPlots/PlotRecipes.jl).
 Ask questions on [gitter](https://gitter.im/tbreloff/Plots.jl) or in the issues.
 


### PR DESCRIPTION
This PR replaces https://docs.juliaplots.org/latest/supported/#keyword-arguments with https://docs.juliaplots.org/stable/generated/supported/#Keyword-Arguments.