### PR TITLE
Fix julia scripts in markdown

### DIFF
--- a/docs/src/internals.md
+++ b/docs/src/internals.md
@@ -9,7 +9,7 @@ defines
 RecipesBase.apply_recipe(plotattributes, args...; kwargs...)
 ```
 returning a `Vector{RecipeData}` where `RecipeData` holds the `plotattributes` Dict and the arguments returned in [`@recipe`](@ref) or in [`@series`](@ref).
-```
+```julia
 struct RecipeData
     plotattributes::AbstractDict{Symbol,Any}
     args::Tuple

--- a/docs/src/types.md
+++ b/docs/src/types.md
@@ -104,11 +104,11 @@ We have already seen an example for a user recipe in the syntax section above.
 User recipes can also be used to define a custom visualization without necessarily wishing to plot a custom type.
 For this purpose we can create a type to dispatch on.
 The [`@userplot`](@ref) macro is a convenient way to do this.
-```
+```julia
 @userplot MyPlot
 ```
 expands to
-```
+```julia
 mutable struct MyPlot
     args
 end
@@ -119,7 +119,7 @@ myplot!(args...; kw...) = plot!(MyPlot(args); kw...)
 
 To check `args` type, define a struct with type parameters.
 
-```
+```julia
 @userplot struct MyPlot{T<:Tuple{AbstractVector}}
     args::T
 end
@@ -259,11 +259,11 @@ We can define a seriestype `:yscaleplot`, that automatically shows data with a l
 end
 ```
 We can call it with `plot(...; ..., seriestype = :yscaleplot)` or we can define a shorthand with the [`@shorthands`](@ref) macro.
-```
+```julia
 @shorthands myseries
 ```
 expands to
-```
+```julia
 export myseries, myseries!
 myseries(args...; kw...) = plot(args...; kw..., seriestype = :myseries)
 myseries!(args...; kw...) = plot!(args...; kw..., seriestype = :myseries)

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -219,7 +219,7 @@ should replace the current arguments.
 
 An example:
 
-```
+```julia
 using RecipesBase
 
 # Our custom type that we want to display
@@ -301,7 +301,7 @@ end
 """
 Meant to be used inside a recipe to add additional RecipeData objects to the list:
 
-```
+```julia
 @recipe function f(::T)
     # everything get this setting
     linecolor --> :red
@@ -334,7 +334,7 @@ end
 
 """
 You can easily define your own plotting recipes with convenience methods:
-```
+```julia
 @userplot GroupHist
 
 @recipe function f(gh::GroupHist)

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -223,7 +223,7 @@ An example:
 using RecipesBase
 
 # Our custom type that we want to display
-type T end
+struct T end
 
 @recipe function plot{N<:Integer}(t::T, n::N = 1; customcolor = :green)
     markershape --> :auto, :require


### PR DESCRIPTION
In the documentation, some syntax highlighting in julia scripts are not working. (e.g. https://juliaplots.org/RecipesBase.jl/stable/api/#RecipesBase.@recipe-Tuple{Expr})
This PR fixes the problem.