### PR TITLE
rework precompilation using `SnoopPrecompile` - document `@layout`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.0'  # lowest declared compat in `Project.toml`
+          - '1.6'  # lowest declared compat in `Project.toml` - lastest LTS
           - '1'
         os: [ubuntu-latest, windows-latest, macOS-latest]
         arch: [x64]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+
+jobs:
+  CI:
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+    env:
+      GKS_ENCODING: "utf8"
+      GKSwstype: "nul"
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.0'  # lowest declared compat in `Project.toml`
+          - '1'
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+        arch: [x64]
+        include:
+          - os: ubuntu-latest
+            prefix: xvfb-run  # julia-actions/julia-runtest/blob/master/README.md
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: julia-actions/setup-julia@latest
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v1
+      - uses: julia-actions/julia-buildpkg@latest
+      - uses: julia-actions/julia-runtest@latest
+        with:
+          prefix: ${{ matrix.prefix }}  # for `xvfb-run`
+      - uses: julia-actions/julia-processcoverage@latest
+      - uses: codecov/codecov-action@v3
+        with:
+          file: lcov.info
+
+  Skip:
+    if: contains(github.event.head_commit.message, '[skip ci]')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Skip CI 🚫
+        run: echo skip ci

--- a/Project.toml
+++ b/Project.toml
@@ -8,7 +8,7 @@ SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
 
 [compat]
 SnoopPrecompile = "1"
-julia = "1"
+julia = "1.6"
 
 [extras]
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"

--- a/Project.toml
+++ b/Project.toml
@@ -3,7 +3,11 @@ uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
 author = ["Tom Breloff (@tbreloff)"]
 version = "1.2.1"
 
+[deps]
+SnoopPrecompile = "66db9d55-30c0-4569-8b51-7e840670fc0c"
+
 [compat]
+SnoopPrecompile = "1"
 julia = "1"
 
 [extras]
@@ -11,4 +15,4 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Random"]
+test = ["Random", "Test"]

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -569,6 +569,34 @@ function create_grid(s::Symbol)
     :((label = $(QuoteNode(s)), blank = $(s == :_)))
 end
 
+"""
+    @layout mat
+
+Generate the subplots layout from a matrix of symbols (where subplots can span multiple rows or columns).
+Precise sizing can be achieved with curly brackets, otherwise the free space is equally split between the plot areas of subplots.
+You can use the `_` character (underscore) to ignore plots in the layout (blank plots).
+
+# Examples
+
+```jldoctest
+julia> @layout([a b; c])
+2×1 Matrix{Any}:
+ Any[(label = :a, blank = false) (label = :b, blank = false)]
+ (label = :c, blank = false)
+
+julia> @layout [a{0.3w}; b{0.2h}]
+2×1 Matrix{Any}:
+ (label = :a, width = 0.3, height = :auto)
+ (label = :b, width = :auto, height = 0.2)
+
+julia> @layout([_ ° _; ° ° °; ° ° °])
+3×3 Matrix{Any}:
+ (label = :_, blank = true)   …  (label = :_, blank = true)
+ (label = :°, blank = false)     (label = :°, blank = false)
+ (label = :°, blank = false)     (label = :°, blank = false)
+
+```
+"""
 macro layout(mat::Expr)
     create_grid(mat)
 end

--- a/src/RecipesBase.jl
+++ b/src/RecipesBase.jl
@@ -1,5 +1,6 @@
-
 module RecipesBase
+
+using SnoopPrecompile
 
 export
     @recipe,
@@ -579,7 +580,7 @@ You can use the `_` character (underscore) to ignore plots in the layout (blank 
 # Examples
 
 ```jldoctest
-julia> @layout([a b; c])
+julia> @layout [a b; c]
 2×1 Matrix{Any}:
  Any[(label = :a, blank = false) (label = :b, blank = false)]
  (label = :c, blank = false)
@@ -589,7 +590,7 @@ julia> @layout [a{0.3w}; b{0.2h}]
  (label = :a, width = 0.3, height = :auto)
  (label = :b, width = :auto, height = 0.2)
 
-julia> @layout([_ ° _; ° ° °; ° ° °])
+julia> @layout [_ ° _; ° ° °; ° ° °]
 3×3 Matrix{Any}:
  (label = :_, blank = true)   …  (label = :_, blank = true)
  (label = :°, blank = false)     (label = :°, blank = false)
@@ -600,6 +601,26 @@ julia> @layout([_ ° _; ° ° °; ° ° °])
 macro layout(mat::Expr)
     create_grid(mat)
 end
-include("precompile.jl")
 
-end # module
+@precompile_setup begin
+    struct __RecipesBasePrecompileType end
+    @precompile_all_calls begin
+        @layout [a b; c]
+        @layout [a{0.3w}; b{0.2h}]
+        @layout [_ ° _; ° ° °; ° ° °]
+        # @userplot __RecipesBasePrecompileType  # fails (export statements)
+        @recipe f(::__RecipesBasePrecompileType) = begin
+            @series begin
+                markershape --> :auto, :require
+                markercolor --> customcolor, :force
+                xrotation --> 5
+                zrotation --> 6, :quiet
+                fillcolor := :green
+                ones(1)
+            end
+            zeros(1)
+        end
+    end
+end
+
+end

--- a/src/precompile.jl
+++ b/src/precompile.jl
@@ -1,9 +1,0 @@
-function _precompile_()
-    ccall(:jl_generating_output, Cint, ()) == 1 || return nothing
-    Base.precompile(Tuple{typeof(RecipesBase.create_kw_body),Expr})
-    Base.precompile(Tuple{typeof(RecipesBase.get_function_def),Expr,Array{Any,1}})
-    Base.precompile(Tuple{typeof(map),Function,Array{AbstractLayout,1}})
-    Base.precompile(Tuple{typeof(map),Function,Array{AbstractLayout,2}})
-end
-
-_precompile_()


### PR DESCRIPTION
- `help?> @layout` is missing;
- rework precompilation using `SnoopPrecompile`;
- I had to raise minimal julia version to LTS `1.6` for the `struct` declaration for `SnoopPrecompile`.


**master**
```julia
@time @time_imports using RecipesBase
     68.6 ms  RecipesBase
  0.142857 seconds (170.86 k allocations: 12.478 MiB, 44.56% compilation time)
```

**PR**
```julia
@time @time_imports using RecipesBase
      0.2 ms  SnoopPrecompile
     57.4 ms  RecipesBase
  0.125814 seconds (149.92 k allocations: 11.182 MiB, 45.83% compilation time)
```